### PR TITLE
Implement Sign Up overlay and integrate with Sign In page

### DIFF
--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -8,6 +8,7 @@ import {authenticate,getUserByLogin} from "../utils/api";
 import Snackbar from "../components/Snackbar";
 import userStore from "../stores/userStore";
 import LoadingSpinner from "../components/LoadingSpinner";
+import SignUp from './SignUp';
 
 const SignIn = () => {
     const [email, setEmail] = useState<string>('');
@@ -16,6 +17,7 @@ const SignIn = () => {
     const [isSnackBarOpen, setIsSnackBarOpen] = React.useState(false);
     const [loginError, setLoginError] = React.useState<string>("");
     const [loading, setLoading] = useState<boolean>(false);
+    const [isSignUpOpen, setIsSignUpOpen] = useState(false);
 
     const handleSignIn = async (e: React.FormEvent) => {
         setLoading(true)
@@ -93,8 +95,12 @@ const SignIn = () => {
                         Sign In
                     </Button>
                 </form>
+                <Button type="button" variant="secondary" size="md" onClick={() => setIsSignUpOpen(true)}>
+                    Sign Up
+                </Button>
             </div>
             }
+                <SignUp isOpen={isSignUpOpen} onClose={() => setIsSignUpOpen(false)} />
                 <Snackbar open={isSnackBarOpen} message={loginError} type={loginError !== "" ? 'error' : "success"} onClose={() => setIsSnackBarOpen(false)}/>
         </div>
     );

--- a/frontend/src/pages/SignUp.test.tsx
+++ b/frontend/src/pages/SignUp.test.tsx
@@ -1,13 +1,19 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SignUp from './SignUp';
 import React from 'react';
 
-describe('SignUp Page', () => {
-  it('renders the Sign Up heading', () => {
-    render(<SignUp />);
+vi.mock('../utils/api', () => ({
+  fetchUserProfiles: vi.fn().mockResolvedValue({ data: [] }),
+  createUser: vi.fn().mockResolvedValue({}),
+}));
+
+describe('SignUp Modal', () => {
+  it('renders form fields when open', () => {
+    render(<SignUp isOpen={true} onClose={() => {}} />);
     expect(screen.getByText(/Sign Up/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/First Name/i)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,10 +1,89 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import Button from '../components/Button';
+import Input from '../components/Input';
+import Dropdown from '../components/Dropdown';
+import Snackbar from '../components/Snackbar';
+import { createUser, fetchUserProfiles } from '../utils/api';
 
-const SignUp = () => {
+interface SignUpProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const SignUp: React.FC<SignUpProps> = ({ isOpen, onClose }) => {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [loginId, setLoginId] = useState('');
+  const [password, setPassword] = useState('');
+  const [userProfile, setUserProfile] = useState('');
+  const [profiles, setProfiles] = useState<{ id: number; userType: string }[]>([]);
+  const [snackOpen, setSnackOpen] = useState(false);
+  const [snackMessage, setSnackMessage] = useState('');
+  const [snackType, setSnackType] = useState<'success' | 'error'>('success');
+
+  useEffect(() => {
+    if (!isOpen) return;
+    fetchUserProfiles()
+      .then((res) => setProfiles(res.data))
+      .catch(() => setProfiles([]));
+  }, [isOpen]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createUser({ firstName, lastName, loginId, password, userProfile });
+      setSnackType('success');
+      setSnackMessage('User created successfully');
+      setFirstName('');
+      setLastName('');
+      setLoginId('');
+      setPassword('');
+      setUserProfile('');
+      onClose();
+    } catch (error) {
+      setSnackType('error');
+      setSnackMessage('Failed to create user');
+    } finally {
+      setSnackOpen(true);
+      setTimeout(() => setSnackOpen(false), 3000);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const options = profiles.map((p) => ({ value: p.userType, label: p.userType }));
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
-      <h1 className="text-2xl font-bold mb-4">Sign Up</h1>
-      {/* Add form fields here */}
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white p-6 rounded-lg shadow-lg w-full max-w-md">
+        <h1 className="text-2xl font-bold mb-4">Sign Up</h1>
+        <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+          <Input label="First Name" value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+          <Input label="Last Name" value={lastName} onChange={(e) => setLastName(e.target.value)} />
+          <Input label="Login Id" value={loginId} onChange={(e) => setLoginId(e.target.value)} />
+          <Input
+            label="Password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Dropdown
+            value={userProfile}
+            onChange={(e) => setUserProfile(e.target.value)}
+            options={options}
+            placeholder="Select profile"
+          />
+          <div className="flex justify-end gap-2 mt-2">
+            <Button type="submit" variant="primary">
+              Sign Up
+            </Button>
+            <Button type="button" variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </div>
+      <Snackbar open={snackOpen} message={snackMessage} type={snackType} onClose={() => setSnackOpen(false)} />
     </div>
   );
 };

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -18,6 +18,8 @@ export const fetchAllUsers = async () => {
 
 export const createUser = (user) => api.post('/users', user);
 
+export const fetchUserProfiles = () => api.get('/userProfiles');
+
 export const updateUser = (id, user) => api.put(`/users/${id}`, user);
 
 export const authenticate = (user: string, pass: string) => {


### PR DESCRIPTION
## Summary
- add modal-based Sign Up component with user profile selection and snackbar notifications
- expose userProfiles API helper
- link Sign Up modal from Sign In page and add unit test

## Testing
- `pnpm test run` *(fails: ReferenceError: expect is not defined)*
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68975628ca5483339da7d70879191720